### PR TITLE
左侧拉开20%，背景色添加部分透明但颜色略微变深保证文字识别方便，自然形成列表仍可滑动

### DIFF
--- a/moe-assisstant/pages/zjsnr/shipinfo/brief/brief.wxss
+++ b/moe-assisstant/pages/zjsnr/shipinfo/brief/brief.wxss
@@ -183,9 +183,9 @@
   position: fixed;
   top: 0;
   bottom: 0;
-  left: 0;
+  left: 20%;
   right: 0;
-  background-color: #f2f6fc;
+  background-color: #dfe7f5bd;
   box-sizing: border-box;
   padding: 20rpx 30rpx;
   overflow: scroll;


### PR DESCRIPTION
微信天然支持多层滑动，就算是完全覆盖也支持，但是完全覆盖的半透明背景很不好看，而且一旦以后筛选太多，筛选view会滑动的时候，就无法让处于低一层的船列表滑动了。拉开20%距离刚好看到船名还算可以（长的只能看到一部分），同时不会让右侧的筛选太过拥挤。