### PR TITLE
双指放大硬代码防手抖版

### DIFF
--- a/moe-assisstant/pages/zjsnr/shipinfo/detail/detail.js
+++ b/moe-assisstant/pages/zjsnr/shipinfo/detail/detail.js
@@ -93,6 +93,8 @@ Page({
     illustrationIndex: 0,
 
     illustrationTouchStartX: 0,
+
+    doubleFinger: 0
   },
   onLoad() {
     this.initData()
@@ -136,10 +138,20 @@ Page({
       this.data.illustrationTouchStartX = e.touches[0].pageX
     } else if (e.touches.length === 2) {
       // 双指缩放事件
+      this.doubleFinger = 2
+      wx.showToast({
+        title: '双指可放大立绘',
+        icon: 'none',
+        duration: 500
+      })
     }
 
   },
   illustrationTouchend(e) {
+    if (this.doubleFinger > 0) {
+      this.doubleFinger -= 1
+      return
+    }
     if (e.changedTouches.length === 1) {
       // 单指滑动事件
       const illustrationTouchEndX = e.changedTouches[0].pageX
@@ -152,13 +164,18 @@ Page({
         this.setData({
           illustrationIndex: app.util.getImageSwipperIndex(newIndex, illustrationLength)
         })
+      } else if (Math.abs(illustrationTouchEndX - this.data.illustrationTouchStartX) < windowWidth / 40) {
+        this.closeImage()
       }
     } else if (e.changedTouches.length === 2) {
-      // 双指缩放事件
     }
 
   },
   closeImage() {
+    if (this.doubleFinger > 0) {
+      this.doubleFinger -= 1
+      return
+    }
     this.setData({
       showIllustration: false
     })

--- a/moe-assisstant/pages/zjsnr/shipinfo/detail/detail.wxml
+++ b/moe-assisstant/pages/zjsnr/shipinfo/detail/detail.wxml
@@ -69,7 +69,10 @@
     </view>
   </view>
 
-  <view class="illustration-container" wx:if="{{showIllustration}}">
-    <image class="illustration" src="{{illustrationList[illustrationIndex]}}" mode="aspectFit" style="background: {{backgroundPicSrc}}" bindtouchstart="illustrationTouchstart" bindtouchend="illustrationTouchend" bindtap="closeImage"></image>
-  </view>
+  <movable-area class="illustration-container" style="width: 100%;height: 100%" wx:if="{{showIllustration}}">
+    <movable-view scale="true" scale-min="1.0" scale-max="2.5" style="width: 100%; height: 100%">
+      <image class="illustration" src="{{illustrationList[illustrationIndex]}}" mode="aspectFit" style="background: {{backgroundPicSrc}}" bindtouchstart="illustrationTouchstart" bindtouchend="illustrationTouchend"></image>
+    </movable-view>
+  </movable-area>
+
 </view>

--- a/moe-assisstant/pages/zjsnr/shipinfo/detail/detail.wxss
+++ b/moe-assisstant/pages/zjsnr/shipinfo/detail/detail.wxss
@@ -109,6 +109,8 @@
   left: 0;
   right: 0;
   background: transparent;
+  width: 100%;
+  height: 100%
 }
 
 .container .illustration-container .illustration {


### PR DESCRIPTION
硬代码防止微信手抖判定直接判定为滑动
去掉了onTap退出，转为用onMoveEnd判断